### PR TITLE
Fix use of rust toolchain action

### DIFF
--- a/.github/workflows/test_pr_dcam.yml
+++ b/.github/workflows/test_pr_dcam.yml
@@ -41,10 +41,6 @@ jobs:
               with:
                   python-version: ${{ matrix.python }}
 
-            - uses: actions-rs/toolchain@v1
-              with:
-                  toolchain: stable
-
             - name: Install
               run: |
                   pip install --upgrade pip

--- a/.github/workflows/test_pr_egrabber.yml
+++ b/.github/workflows/test_pr_egrabber.yml
@@ -41,10 +41,6 @@ jobs:
               with:
                   python-version: ${{ matrix.python }}
 
-            - uses: actions-rs/toolchain@v1
-              with:
-                  toolchain: stable
-
             - name: Install
               run: |
                   pip install --upgrade pip


### PR DESCRIPTION
Looks like the action we were using for installing the rust toolchain has lacked a maintainer for a while (see actions-rs/toolchain#216).

There's a maintained alternative, but it looks like the maturin install might take care of things...