### PR TITLE
rename instances of acquire-python to acquire-imaging

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -21,6 +21,6 @@ authors:
 repository-code: 'https://github.com/acquire-project/acquire-python'
 repository-artifact: 'https://pypi.org/project/acquire-imaging/'
 abstract: >-
-  acquire-python is a library focusing on multi-camera video
+  acquire-imaging is a library focusing on multi-camera video
   streaming for microscopy.
 license: Apache-2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,10 +26,10 @@ testing = [
 ]
 
 [project.entry-points."napari.manifest"]
-acquire-python = "acquire:napari.yaml"
+acquire-imaging = "acquire:napari.yaml"
 
 [tool.setuptools.package_data]
-acquire-python = [
+acquire-imaging = [
     "napari.yaml",
     "libacquire-driver-common.so",
     "libacquire-driver-egrabber.so",

--- a/python/acquire/napari.yaml
+++ b/python/acquire/napari.yaml
@@ -1,11 +1,11 @@
-name: acquire-python
+name: acquire-imaging
 display_name: Acquire
 contributions:
   commands:
-    - id: acquire-python.gui
+    - id: acquire-imaging.gui
       title: Demo video streaming with Acquire
       python_name: acquire:gui
   widgets:
-    - command: acquire-python.gui
+    - command: acquire-imaging.gui
       display_name: Stream
       autogenerate: true


### PR DESCRIPTION
I noticed this when trying to load an Acquire-generated image into napari:

```
ERROR npe2.manifest.schema 2023-06-01 10:19:56,536 schema.py:370 napari.manifest -> 'acquire-imaging' could not be imported: The name field in the manifest ('acquire-python') must match the package name ('acquire-imaging')
```

This should fix that. Also renames references in pyproject.toml and CITATION.cff. Less sure about these.