### PR TITLE
Fetch drivers to a dir outside of the link search path

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -27,25 +27,25 @@ fn main() {
     let tags: DriverManifest = serde_json::from_str(drivers_json.as_str())
         .expect("Failed to parse drivers.json");
 
-    let out = std::path::PathBuf::from(std::env::var("OUT_DIR").unwrap());
+    let drivers_dir = std::path::PathBuf::from(std::env::var("OUT_DIR").unwrap()).join("drivers");
 
     fetch_acquire_driver(
-        &out,
+        &drivers_dir,
         "acquire-driver-common",
         tags.acquire_driver_common.as_str(),
     );
     fetch_acquire_driver(
-        &out,
+        &drivers_dir,
         "acquire-driver-zarr",
         tags.acquire_driver_zarr.as_str(),
     );
     fetch_acquire_driver(
-        &out,
+        &drivers_dir,
         "acquire-driver-egrabber",
         tags.acquire_driver_egrabber.as_str(),
     );
     fetch_acquire_driver(
-        &out,
+        &drivers_dir,
         "acquire-driver-hdcam",
         tags.acquire_driver_hdcam.as_str(),
     );
@@ -71,7 +71,7 @@ fn main() {
         .expect("Unable to generate bindings");
 
     bindings
-        .write_to_file(out.join("bindings.rs"))
+        .write_to_file(dst.join("bindings.rs"))
         .expect("Failed to write bindings.");
 }
 


### PR DESCRIPTION
As discussed in today's standup, and related to #76, this works for me to build a working ARM wheel (locally) even with mismatched driver architecture. The result is a much less surprising and more descriptive error:

```
❯ python
Python 3.10.13 (main, Sep 20 2023, 16:38:58) [Clang 14.0.0 (clang-1400.0.29.202)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import acquire
Log: warn enabled
Log: error enabled
>>> acquire.Runtime()
/Users/aandersoniii/src/acquire-python/acquire-video-runtime/src/acquire-core-libs/src/acquire-core-platform/osx/platform.c:354 - lib_open(): Failed to load /Users/aandersoniii/src/acquire-python/python/acquire/libacquire-driver-common.so. Error: dlopen(/Users/aandersoniii/src/acquire-python/python/acquire/libacquire-driver-common.so, 0x0006): tried: '/Users/aandersoniii/src/acquire-python/python/acquire/libacquire-driver-common.so' (mach-o file, but is an incompatible architecture (have 'x86_64', need 'arm64')), '/System/Volumes/Preboot/Cryptexes/OS/Users/aandersoniii/src/acquire-python/python/acquire/libacquire-driver-common.so' (no such file), '/Users/aandersoniii/src/acquire-python/python/acquire/libacquire-driver-common.so' (mach-o file, but is an incompatible architecture (have 'x86_64', need 'arm64'))
/Users/aandersoniii/src/acquire-python/acquire-video-runtime/src/acquire-core-libs/src/acquire-device-hal/device/hal/loader.c:114 - driver_load(): Failed to load driver at "acquire-driver-common".
/Users/aandersoniii/src/acquire-python/acquire-video-runtime/src/acquire-core-libs/src/acquire-core-platform/osx/platform.c:354 - lib_open(): Failed to load /Users/aandersoniii/src/acquire-python/python/acquire/libacquire-driver-hdcam.so. Error: dlopen(/Users/aandersoniii/src/acquire-python/python/acquire/libacquire-driver-hdcam.so, 0x0006): tried: '/Users/aandersoniii/src/acquire-python/python/acquire/libacquire-driver-hdcam.so' (mach-o file, but is an incompatible architecture (have 'x86_64', need 'arm64')), '/System/Volumes/Preboot/Cryptexes/OS/Users/aandersoniii/src/acquire-python/python/acquire/libacquire-driver-hdcam.so' (no such file), '/Users/aandersoniii/src/acquire-python/python/acquire/libacquire-driver-hdcam.so' (mach-o file, but is an incompatible architecture (have 'x86_64', need 'arm64'))
/Users/aandersoniii/src/acquire-python/acquire-video-runtime/src/acquire-core-libs/src/acquire-device-hal/device/hal/loader.c:114 - driver_load(): Failed to load driver at "acquire-driver-hdcam".
/Users/aandersoniii/src/acquire-python/acquire-video-runtime/src/acquire-core-libs/src/acquire-core-platform/osx/platform.c:354 - lib_open(): Failed to load /Users/aandersoniii/src/acquire-python/python/acquire/libacquire-driver-zarr.so. Error: dlopen(/Users/aandersoniii/src/acquire-python/python/acquire/libacquire-driver-zarr.so, 0x0006): tried: '/Users/aandersoniii/src/acquire-python/python/acquire/libacquire-driver-zarr.so' (mach-o file, but is an incompatible architecture (have 'x86_64', need 'arm64')), '/System/Volumes/Preboot/Cryptexes/OS/Users/aandersoniii/src/acquire-python/python/acquire/libacquire-driver-zarr.so' (no such file), '/Users/aandersoniii/src/acquire-python/python/acquire/libacquire-driver-zarr.so' (mach-o file, but is an incompatible architecture (have 'x86_64', need 'arm64'))
/Users/aandersoniii/src/acquire-python/acquire-video-runtime/src/acquire-core-libs/src/acquire-device-hal/device/hal/loader.c:114 - driver_load(): Failed to load driver at "acquire-driver-zarr".
/Users/aandersoniii/src/acquire-python/acquire-video-runtime/src/acquire-core-libs/src/acquire-core-platform/osx/platform.c:354 - lib_open(): Failed to load /Users/aandersoniii/src/acquire-python/python/acquire/libacquire-driver-egrabber.so. Error: dlopen(/Users/aandersoniii/src/acquire-python/python/acquire/libacquire-driver-egrabber.so, 0x0006): tried: '/Users/aandersoniii/src/acquire-python/python/acquire/libacquire-driver-egrabber.so' (mach-o file, but is an incompatible architecture (have 'x86_64', need 'arm64')), '/System/Volumes/Preboot/Cryptexes/OS/Users/aandersoniii/src/acquire-python/python/acquire/libacquire-driver-egrabber.so' (no such file), '/Users/aandersoniii/src/acquire-python/python/acquire/libacquire-driver-egrabber.so' (mach-o file, but is an incompatible architecture (have 'x86_64', need 'arm64'))
/Users/aandersoniii/src/acquire-python/acquire-video-runtime/src/acquire-core-libs/src/acquire-device-hal/device/hal/loader.c:114 - driver_load(): Failed to load driver at "acquire-driver-egrabber".
<builtins.Runtime object at 0x10576f3b0>
>>> 
```