### PR TITLE
Change configure to set_configuration in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,22 +44,22 @@ print(acquire.Runtime().device_manager().devices())
 
 ```python
 import acquire
-runtime=acquire.Runtime()
-dm=runtime.device_manager()
+runtime = acquire.Runtime()
+dm = runtime.device_manager()
 
-props=runtime.get_configuration()
+props = runtime.get_configuration()
 # select the first Hamamatsu camera
 props.video[0].camera.identifier = dm.select(DeviceKind.Camera, "hamamatsu.*")
 # stream to zarr
 props.video[0].storage.identifier = dm.select(DeviceKind.Storage, "zarr")
-props.video[0].storage.settings.filename="out.zarr"
+props.video[0].storage.settings.filename = "out.zarr"
 props.video[0].camera.settings.shape = (2304, 2304)
 props.video[0].camera.settings.pixel_type = SampleType.U16
 props.video[0].max_frame_count = 100
-props=runtime.configure(props)
+props = runtime.set_configuration(props)
 
 runtime.start()
-runtime.stop() # wait for acquisition to complete
+runtime.stop()  # wait for acquisition to complete
 ```
 
 # Development


### PR DESCRIPTION
This came up during testing at the Biohub. I also made the spacing more consistent with PEP 8.