### PR TITLE
Update TriggerEdge enum members to match C headers

### DIFF
--- a/python/acquire/acquire.pyi
+++ b/python/acquire/acquire.pyi
@@ -242,6 +242,7 @@ class Trigger:
 @final
 class TriggerEdge:
     Falling: ClassVar[TriggerEdge] = TriggerEdge.Falling
+    NotApplicable: ClassVar[TriggerEdge] = TriggerEdge.NotApplicable
     Rising: ClassVar[TriggerEdge] = TriggerEdge.Rising
     AnyEdge: ClassVar[TriggerEdge] = TriggerEdge.AnyEdge
     LevelLow: ClassVar[TriggerEdge] = TriggerEdge.LevelLow

--- a/python/acquire/acquire.pyi
+++ b/python/acquire/acquire.pyi
@@ -242,8 +242,10 @@ class Trigger:
 @final
 class TriggerEdge:
     Falling: ClassVar[TriggerEdge] = TriggerEdge.Falling
-    NotApplicable: ClassVar[TriggerEdge] = TriggerEdge.NotApplicable
     Rising: ClassVar[TriggerEdge] = TriggerEdge.Rising
+    AnyEdge: ClassVar[TriggerEdge] = TriggerEdge.AnyEdge
+    LevelLow: ClassVar[TriggerEdge] = TriggerEdge.LevelLow
+    LevelHigh: ClassVar[TriggerEdge] = TriggerEdge.LevelHigh
     def __eq__(self, other: object) -> bool: ...
     def __ge__(self, other: object) -> bool: ...
     def __gt__(self, other: object) -> bool: ...

--- a/src/components/trigger_edge.rs
+++ b/src/components/trigger_edge.rs
@@ -9,6 +9,7 @@ use anyhow::anyhow;
 pub enum TriggerEdge {
     Rising,
     Falling,
+    NotApplicable,
     AnyEdge,
     LevelHigh,
     LevelLow,
@@ -23,6 +24,7 @@ impl Default for TriggerEdge {
 cvt!( TriggerEdge => capi::TriggerEdge,
     Rising => TriggerEdge_TriggerEdge_Rising,
     Falling => TriggerEdge_TriggerEdge_Falling,
+    NotApplicable => TriggerEdge_TriggerEdge_NotApplicable,
     AnyEdge => TriggerEdge_TriggerEdge_AnyEdge,
     LevelHigh => TriggerEdge_TriggerEdge_LevelHigh,
     LevelLow => TriggerEdge_TriggerEdge_LevelLow

--- a/src/components/trigger_edge.rs
+++ b/src/components/trigger_edge.rs
@@ -9,7 +9,9 @@ use anyhow::anyhow;
 pub enum TriggerEdge {
     Rising,
     Falling,
-    NotApplicable,
+    AnyEdge,
+    LevelHigh,
+    LevelLow,
 }
 
 impl Default for TriggerEdge {
@@ -21,5 +23,7 @@ impl Default for TriggerEdge {
 cvt!( TriggerEdge => capi::TriggerEdge,
     Rising => TriggerEdge_TriggerEdge_Rising,
     Falling => TriggerEdge_TriggerEdge_Falling,
-    NotApplicable => TriggerEdge_TriggerEdge_NotApplicable
+    AnyEdge => TriggerEdge_TriggerEdge_AnyEdge,
+    LevelHigh => TriggerEdge_TriggerEdge_LevelHigh,
+    LevelLow => TriggerEdge_TriggerEdge_LevelLow
 );


### PR DESCRIPTION
This modifies the Rust definition and therefore Python definition of the `TriggerEdge` enum so that it defines the same members as [the corresponding C enum](https://github.com/acquire-project/acquire-core-libs/blob/40e71b2af97f8827be5d88352414365193145ed3/src/acquire-device-properties/device/props/components.h#L36) up to the `TriggerEdgeCount` member.

Technically, this is a breaking change to the Python API because it removes the `NotApplicable` member, which is beyond the count member in the C definition. We could consider keeping the `NotApplicable` member to avoid that breaking change.