### PR TITLE
Update some drivers for OSX universal builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request: # TODO (aliddell): remove before merge
-    branches:
-      - main
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  pull_request: # TODO (aliddell): remove before merge
+    branches:
+      - main
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  pull_request:  # TODO (aliddell): remove me
+    branches:
+      - main
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:  # TODO (aliddell): remove me
-    branches:
-      - main
 
 jobs:
   build:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "acquire-imaging"
 authors = ["Nathan Clack <nclack@chanzuckerberg.com>"]
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 
 [lib]

--- a/build.rs
+++ b/build.rs
@@ -21,6 +21,7 @@ fn main() {
         .define("NO_UNIT_TESTS", "TRUE")
         .define("NO_EXAMPLES", "TRUE")
         .define("CMAKE_OSX_DEPLOYMENT_TARGET", "10.15")
+        .define("CMAKE_OSX_ARCHITECTURES", "x86_64;arm64")
         .build();
 
     let drivers_json =

--- a/drivers.json
+++ b/drivers.json
@@ -1,7 +1,7 @@
 {
-  "acquire-driver-common": "0.1.5",
+  "acquire-driver-common": "0.1.6",
   "acquire-driver-zarr": "0.1.7",
-  "acquire-driver-egrabber": "0.1.4",
-  "acquire-driver-hdcam": "0.1.6",
+  "acquire-driver-egrabber": "0.1.5",
+  "acquire-driver-hdcam": "0.1.7",
   "acquire-driver-spinnaker": "0.1.1"
 }


### PR DESCRIPTION
The versions for `acquire-driver-common`, `acquire-driver-hdcam`, and `acquire-driver-egrabber` were out of date. This PR updates them and thereby fixes a regression where Acquire can't be imported on ARM Macs.