### PR TITLE
Prep for 0.3.0 rc3 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "acquire-imaging"
 authors = ["Nathan Clack <nclack@chanzuckerberg.com>"]
-version = "0.3.0-rc2"
+version = "0.3.0-rc3"
 edition = "2021"
 
 [lib]

--- a/drivers.json
+++ b/drivers.json
@@ -1,7 +1,7 @@
 {
   "acquire-driver-zarr": "0.1.9",
   "acquire-driver-egrabber": "0.1.5",
-  "acquire-driver-hdcam": "0.1.7",
+  "acquire-driver-hdcam": "0.1.8",
   "acquire-driver-spinnaker": "0.1.1",
   "acquire-driver-pvcam": "0.1.0"
 }


### PR DESCRIPTION
- Fixes a race condition on abort.
- Updates DCAM driver to guarantee a software trigger when `acquire_execute_trigger()` is called.