### PR TITLE
Fix build failures on macOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     strategy:
       matrix:
-        platform: [ windows-latest, macos-latest, ubuntu-latest ]
+        platform: [ windows-latest, macos-13, ubuntu-latest ]
 
     runs-on: ${{matrix.platform}}
     steps:
@@ -21,7 +21,7 @@ jobs:
           submodules: true
 
       - name: Build (macOS)
-        if: matrix.platform == 'macos-latest'
+        if: matrix.platform == 'macos-13'
         uses: messense/maturin-action@v1
         with:
           command: build
@@ -29,7 +29,7 @@ jobs:
           args: --release -o dist
 
       - name: Build
-        if: matrix.platform != 'macos-latest'
+        if: matrix.platform != 'macos-13'
         uses: messense/maturin-action@v1
         with:
           command: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,16 @@ jobs:
         with:
           submodules: true
 
+      - name: Build (macOS)
+        if: matrix.platform == 'macos-latest'
+        uses: messense/maturin-action@v1
+        with:
+          command: build
+          target: universal2-apple-darwin
+          args: --release -o dist
+
       - name: Build
+        if: matrix.platform != 'macos-latest'
         uses: messense/maturin-action@v1
         with:
           command: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,16 +20,7 @@ jobs:
         with:
           submodules: true
 
-      - name: Build (macOS)
-        if: matrix.platform == 'macos-latest'
-        uses: messense/maturin-action@v1
-        with:
-          command: build
-          target: universal2-apple-darwin
-          args: --release -o dist
-
       - name: Build
-        if: matrix.platform != 'macos-latest'
         uses: messense/maturin-action@v1
         with:
           command: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     strategy:
       matrix:
-        platform: [ windows-latest, macos-13, ubuntu-latest ]
+        platform: [ windows-latest, macos-latest, ubuntu-latest ]
 
     runs-on: ${{matrix.platform}}
     steps:
@@ -21,7 +21,7 @@ jobs:
           submodules: true
 
       - name: Build (macOS)
-        if: matrix.platform == 'macos-13'
+        if: matrix.platform == 'macos-latest'
         uses: messense/maturin-action@v1
         with:
           command: build
@@ -29,7 +29,7 @@ jobs:
           args: --release -o dist
 
       - name: Build
-        if: matrix.platform != 'macos-13'
+        if: matrix.platform != 'macos-latest'
         uses: messense/maturin-action@v1
         with:
           command: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   build:
@@ -17,16 +20,7 @@ jobs:
         with:
           submodules: true
 
-      - name: Build (macOS)
-        if: matrix.platform == 'macos-latest'
-        uses: messense/maturin-action@v1
-        with:
-          command: build
-          target: universal2-apple-darwin
-          args: --release -o dist
-
       - name: Build
-        if: matrix.platform != 'macos-latest'
         uses: messense/maturin-action@v1
         with:
           command: build

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ anyhow = "1.0"
 parking_lot = "0.12"
 serde = { version = "1.0", features = ["derive"] }
 pythonize = "0.20.0"
+cc = "1.0.83"
 
 [build-dependencies]
 bindgen = "0.69.1"
@@ -32,4 +33,3 @@ reqwest = { version = "0.11", features = ["blocking", "json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 zip-extract = "0.1"
-cc = "1.0.83"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ anyhow = "1.0"
 parking_lot = "0.12"
 serde = { version = "1.0", features = ["derive"] }
 pythonize = "0.20.0"
-cc = "1.0.83"
 
 [build-dependencies]
 bindgen = "0.69.1"
@@ -33,3 +32,4 @@ reqwest = { version = "0.11", features = ["blocking", "json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 zip-extract = "0.1"
+cc = "1.0.83"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ anyhow = "1.0"
 parking_lot = "0.12"
 serde = { version = "1.0", features = ["derive"] }
 pythonize = "0.20.0"
-cc = "1.0.83"
 
 [build-dependencies]
 bindgen = "0.69.1"
@@ -33,4 +32,4 @@ reqwest = { version = "0.11", features = ["blocking", "json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 zip-extract = "0.1"
-cc = "1.0.83"
+cc = "=1.0.83"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,4 @@ reqwest = { version = "0.11", features = ["blocking", "json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 zip-extract = "0.1"
+cc = "1.0.83"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ anyhow = "1.0"
 parking_lot = "0.12"
 serde = { version = "1.0", features = ["derive"] }
 pythonize = "0.20.0"
+cc = "1.0.83"
 
 [build-dependencies]
 bindgen = "0.69.1"

--- a/build.rs
+++ b/build.rs
@@ -19,7 +19,6 @@ fn main() {
         serde_json::from_str(drivers_json.as_str()).expect("Failed to parse drivers.json");
 
     let dst = cmake::Config::new("acquire-common")
-        .target("acquire-common")
         .profile("RelWithDebInfo")
         .static_crt(true)
         .define("NOTEST", "TRUE")

--- a/build.rs
+++ b/build.rs
@@ -26,6 +26,7 @@ fn main() {
         .define("NO_EXAMPLES", "TRUE")
         .define("CMAKE_OSX_DEPLOYMENT_TARGET", "10.15")
         .define("CMAKE_OSX_ARCHITECTURES", "x86_64;arm64")
+        .very_verbose(true) // TODO: remove this
         .build();
 
     println!("cargo:rustc-link-search=native={}/lib", dst.display());

--- a/build.rs
+++ b/build.rs
@@ -26,7 +26,6 @@ fn main() {
         .define("NO_EXAMPLES", "TRUE")
         .define("CMAKE_OSX_DEPLOYMENT_TARGET", "10.15")
         .define("CMAKE_OSX_ARCHITECTURES", "x86_64;arm64")
-        .very_verbose(true) // TODO: remove this
         .build();
 
     println!("cargo:rustc-link-search=native={}/lib", dst.display());


### PR DESCRIPTION
- Pin cc dependency to 1.0.83 ([possible issue](https://github.com/rust-lang/cc-rs/issues/959)).
- Remove erroneously specified [target triple ](https://docs.rs/cmake/latest/cmake/struct.Config.html#method.target) in build script.
- Consolidate build jobs between target platforms.
