### PR TITLE
export names in __init__.pyi

### DIFF
--- a/python/acquire/__init__.py
+++ b/python/acquire/__init__.py
@@ -15,6 +15,16 @@ import numpy.typing as npt
 from . import acquire
 from .acquire import *
 
+__all__ = [
+    "Runtime",
+    "Properties",
+    "setup",
+    "setup_one_streams",
+    "setup_two_streams",
+    "g_runtime",
+    "gui",
+]
+
 __doc__ = acquire.__doc__
 
 import logging

--- a/python/acquire/__init__.pyi
+++ b/python/acquire/__init__.pyi
@@ -4,6 +4,16 @@ import napari  # type: ignore
 
 from .acquire import Runtime, Properties
 
+__all__ = [
+    "Runtime",
+    "Properties",
+    "setup",
+    "setup_one_streams",
+    "setup_two_streams",
+    "g_runtime",
+    "gui",
+]
+
 def setup(
     runtime: Runtime,
     camera: Union[str, List[str]] = ...,


### PR DESCRIPTION
without explicitly exporting names in `__init__.pyi`, type checkers like mypy won't follow all the names and you won't get autocompletion and code highlighting.  I know it's annoying to have to manually do this (and perhaps you will want to automate it if you're autogenerating your type stubs) ... but adding `__all__` is important one way or the other

before this PR:

<img width="930" alt="Screenshot 2024-03-04 at 7 27 06 PM" src="https://github.com/acquire-project/acquire-python/assets/1609449/ecaca2e0-14d2-4017-8007-9c73a9ca0bfb">
<img width="440" alt="Screenshot 2024-03-04 at 7 30 54 PM" src="https://github.com/acquire-project/acquire-python/assets/1609449/2d910ec4-8ed6-4ebc-b40e-dff9946e8741">


after this PR:

<img width="705" alt="Screenshot 2024-03-04 at 7 30 24 PM" src="https://github.com/acquire-project/acquire-python/assets/1609449/131ac12d-5bbc-4aa1-bb45-2b2194a2f221">
