### PR TITLE
Add storage dimensions for eGrabber tests.

### DIFF
--- a/tests/test_egrabber.py
+++ b/tests/test_egrabber.py
@@ -7,16 +7,10 @@ from acquire import DeviceKind, SampleType
 from acquire.acquire import Trigger
 
 
-@pytest.fixture(scope="module")
-def _runtime():
+@pytest.fixture(scope="function")
+def runtime():
     runtime = acquire.Runtime()
     yield runtime
-
-
-@pytest.fixture(scope="function")
-def runtime(_runtime: acquire.Runtime):
-    yield _runtime
-    _runtime.set_configuration(acquire.Properties())
 
 
 def test_vieworks_camera_is_present(runtime: acquire.Runtime):

--- a/tests/test_egrabber.py
+++ b/tests/test_egrabber.py
@@ -49,6 +49,34 @@ def test_vieworks_stream(
     p.video[0].storage.settings.pixel_scale_um = (0.2, 0.2)
     p.video[0].max_frame_count = 10
 
+    # configure storage dimensions
+    dimension_x = acquire.StorageDimension(
+        name="x",
+        kind="Space",
+        array_size_px=p.video[0].camera.settings.shape[0],
+        chunk_size_px=p.video[0].camera.settings.shape[0] // 2,
+    )
+
+    dimension_y = acquire.StorageDimension(
+        name="y",
+        kind="Space",
+        array_size_px=p.video[0].camera.settings.shape[1],
+        chunk_size_px=p.video[0].camera.settings.shape[1] // 2,
+    )
+
+    dimension_t = acquire.StorageDimension(
+        name="t",
+        kind="Time",
+        array_size_px=0,
+        chunk_size_px=p.video[0].max_frame_count,
+    )
+
+    p.video[0].storage.settings.acquisition_dimensions = [
+        dimension_x,
+        dimension_y,
+        dimension_t,
+    ]
+
     p = runtime.set_configuration(p)
 
     logging.info(pprint.pformat(p.dict()))


### PR DESCRIPTION
Now that the eGrabber runner is working again, we need to update the tests to reflect changes in the required settings when writing to Zarr.