### PR TITLE
S3 in CI

### DIFF
--- a/.github/workflows/test_pr.yml
+++ b/.github/workflows/test_pr.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-  pull_request_target:
+  pull_request:
     branches:
       - main
 
@@ -281,35 +281,3 @@ jobs:
 
       - name: Run stubtest on typed modules
         run: stubtest acquire
-
-  merge:
-    name: Automerge
-    runs-on: "ubuntu-latest"
-    needs:
-      - platforms
-      - dcam
-      #      - egrabber
-      - spinnaker
-      - pvcam
-      - typing
-    if: ${{ github.actor == 'dependabot[bot]' }}
-    steps:
-      - name: Checkout PR
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-
-      - name: Approve PR
-        run: gh pr review --approve "$PR_URL"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.PAT }}
-
-      # Don't auto-merge major version updates
-      - name: Merge PR
-        if: ${{ steps.dependabot-metadata.outputs.update-type != 'version-update:semver-major' }}
-        run: gh pr merge --auto --squash "$PR_URL"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.PAT }}

--- a/.github/workflows/test_s3.yml
+++ b/.github/workflows/test_s3.yml
@@ -1,0 +1,45 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  s3:
+    name: Test S3 functionality
+    runs-on: ubuntu-latest
+    env:
+      MINIO_ROOT_USER: admin
+      MINIO_ROOT_PASSWORD: password
+      MINIO_URL: http://localhost:9000
+      MINIO_ALIAS: myminio
+      MINIO_ACCESS_KEY: acquire
+      MINIO_SECRET_KEY: 12345678
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - name: Install minio and mcli
+        run: |
+          apt update && apt install -y tmux wget
+          wget https://dl.min.io/server/minio/release/linux-amd64/minio_20240726204821.0.0_amd64.deb
+          dpkg -i minio_20240726204821.0.0_amd64.deb
+          
+          wget https://dl.min.io/client/mc/release/linux-amd64/mcli_20240726130844.0.0_amd64.deb
+          dpkg -i mcli_20240726130844.0.0_amd64.deb
+
+      - name: Start minio in tmux
+        run: |
+          tmux new -d -s minio
+          tmux send-keys -t minio "MINIO_ROOT_USER=$MINIO_ROOT_USER MINIO_ROOT_PASSWORD=$MINIO_ROOT_PASSWORD minio server /tmp/minio --console-address :9001" Enter
+          sleep 5
+          mcli alias set $MINIO_ALIAS $MINIO_URL $MINIO_ROOT_USER $MINIO_ROOT_PASSWORD
+          mcli admin user svcacct add --access-key $MINIO_ACCESS_KEY --secret-key $MINIO_SECRET_KEY $MINIO_ALIAS $MINIO_ROOT_USER

--- a/.github/workflows/test_s3.yml
+++ b/.github/workflows/test_s3.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: Test S3
 
 on:
   push:

--- a/.github/workflows/test_s3.yml
+++ b/.github/workflows/test_s3.yml
@@ -30,11 +30,10 @@ jobs:
       - name: Install minio and mcli
         run: |
           apt update && apt install -y tmux wget
-          wget https://dl.min.io/server/minio/release/linux-amd64/minio_20240726204821.0.0_amd64.deb
-          dpkg -i minio_20240726204821.0.0_amd64.deb
-          
-          wget https://dl.min.io/client/mc/release/linux-amd64/mcli_20240726130844.0.0_amd64.deb
-          dpkg -i mcli_20240726130844.0.0_amd64.deb
+          wget https://dl.min.io/server/minio/release/linux-amd64/minio -O /usr/local/bin/minio
+          wget https://dl.min.io/client/mc/release/linux-amd64/mc -O /usr/local/bin/mcli
+          chmod +x /usr/local/bin/minio
+          chmod +x /usr/local/bin/mcli
 
       - name: Start minio in tmux
         run: |


### PR DESCRIPTION
This PR does 2 things:

- Runs tests on the `pull_request` target rather than `pull_request_target` target and removes the automerge job.
- Adds a workflow which spins up an S3 server in CI. It doesn't do much yet, but we would like to see it running and not failing.